### PR TITLE
Add endpoint to calculate subcharacteristics

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.10
+          python-version: 3.10.6
           architecture: x64
       - name: Checkout PyTorch
         uses: actions/checkout@master

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -17,9 +17,9 @@ jobs:
 
     steps:
       - name: Setup Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
-          python-version: 3.10.5
+          python-version: 3.10
           architecture: x64
       - name: Checkout PyTorch
         uses: actions/checkout@master

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,9 @@ services:
     restart: on-failure
     networks:
       - measuresoftgram
+    environment:
+      - DEBUG=True
+
 
 networks:
   measuresoftgram:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.isort]
+profile = "black"

--- a/server.py
+++ b/server.py
@@ -1,5 +1,13 @@
+import os
 from src.app import app
 
 if __name__ == "__main__":
     app.url_map.strict_slashes = False
-    app.run(host="0.0.0.0", debug=True, port=5000)
+
+    DEBUG = os.getenv("DEBUG", "False").lower() in ("true", "1")
+
+    app.run(
+        host="0.0.0.0",
+        debug=DEBUG,
+        port=5000,
+    )

--- a/src/app.py
+++ b/src/app.py
@@ -1,14 +1,10 @@
 from flask import Flask
 from flask_restful import Api
-from src.resources.available import AvailablePreConfigs
-from src.resources.analysis import (
-    Analysis,
-    CalculateMeasures,
-    CalculateSubcharacteristics,
-    CalculateCharacteristics,
-    CalculateSQC,
-)
 
+from src.resources.analysis import (Analysis, CalculateCharacteristics,
+                                    CalculateMeasures, CalculateSQC,
+                                    CalculateSubcharacteristics)
+from src.resources.available import AvailablePreConfigs
 
 app = Flask(__name__)
 api = Api(app)

--- a/src/app.py
+++ b/src/app.py
@@ -1,9 +1,13 @@
 from flask import Flask
 from flask_restful import Api
 
-from src.resources.analysis import (Analysis, CalculateCharacteristics,
-                                    CalculateMeasures, CalculateSQC,
-                                    CalculateSubcharacteristics)
+from src.resources.analysis import (
+    Analysis,
+    CalculateCharacteristics,
+    CalculateMeasures,
+    CalculateSQC,
+    CalculateSubcharacteristics,
+)
 from src.resources.available import AvailablePreConfigs
 
 app = Flask(__name__)

--- a/src/core/agregation.py
+++ b/src/core/agregation.py
@@ -1,9 +1,9 @@
 import numpy as np
 
 
-def agregation_operation(weighted_value, weigths):
+def aggregation_operation(weighted_value, weights):
     weighted_value = np.array(weighted_value)
-    weigths = np.array(weigths)
+    weights = np.array(weights)
     normalized_value = np.linalg.norm(weighted_value)
-    max_value = np.linalg.norm(weigths)
+    max_value = np.linalg.norm(weights)
     return normalized_value / max_value

--- a/src/core/analysis.py
+++ b/src/core/analysis.py
@@ -1,33 +1,26 @@
-from typing import Dict, List
+from typing import Dict, List, Tuple
 
 import pandas as pd
 from src.core.weighting import weighting_operation
-from src.core.agregation import agregation_operation
+from src.core.agregation import aggregation_operation
 from src.util.constants import MEASURES_INTERPRETATION_MAPPING
 
 
-def resolve_level(level_dict: dict, sublevel: dict, sublevel_key: str) -> dict:
-    aggregated_level = {}
-    all_weighted_values = {}
+def resolve_level(level_dict: dict, sublevel: dict, sublevel_key: str) -> Tuple[dict, dict]:
+    aggregated_level, all_weighted_values = {}, {}
     for key, value in level_dict.items():
         level_items = value[sublevel_key]
         level_weights = value["weights"]
 
-        weights_list = []
-        values_list = []
-
-        for idx in range(len(level_items)):
-            item = level_items[idx]
+        weights_list, values_list = [], []
+        for item in level_items:
             weights_list.append(level_weights[item])
             values_list.append(sublevel[item])
 
         weighted_items = weighting_operation(values_list, weights_list)
-        aggregated_value = agregation_operation(weighted_items, weights_list)
+        aggregated_value = aggregation_operation(weighted_items, weights_list)
 
-        weighted_items_dict = {}
-        for idx in range(len(level_items)):
-            item = level_items[idx]
-            weighted_items_dict[item] = weighted_items[idx]
+        weighted_items_dict = {item: weighted_items[idx] for idx, item in enumerate(level_items)}
 
         aggregated_level[key] = aggregated_value
         all_weighted_values[key] = weighted_items_dict
@@ -77,3 +70,9 @@ def calculate_measures(dataframe: pd.DataFrame, measures: List[str]) -> Dict[str
         combined_measures[measure] = MEASURES_INTERPRETATION_MAPPING[measure]["interpretation_function"](dataframe)
 
     return combined_measures
+
+
+def calculate_aggregated_value(values_list: List[float], weights_list: List[float]) -> float:
+    weighted_items = weighting_operation(values_list, weights_list)
+    aggregated_value = aggregation_operation(weighted_items, weights_list)
+    return aggregated_value

--- a/src/core/analysis.py
+++ b/src/core/analysis.py
@@ -73,7 +73,9 @@ def calculate_measures(dataframe: pd.DataFrame, measures: List[str]) -> Dict[str
     return combined_measures
 
 
-def calculate_aggregated_value(values_list: List[float], weights_list: List[float]) -> float:
+def calculate_aggregated_value(
+    values_list: List[float],
+    weights_list: List[float],
+) -> float:
     weighted_items = weighting_operation(values_list, weights_list)
-    aggregated_value = aggregation_operation(weighted_items, weights_list)
-    return aggregated_value
+    return aggregation_operation(weighted_items, weights_list)

--- a/src/core/analysis.py
+++ b/src/core/analysis.py
@@ -1,8 +1,9 @@
 from typing import Dict, List, Tuple
 
 import pandas as pd
-from src.core.weighting import weighting_operation
+
 from src.core.agregation import aggregation_operation
+from src.core.weighting import weighting_operation
 from src.util.constants import MEASURES_INTERPRETATION_MAPPING
 
 

--- a/src/core/dataframe.py
+++ b/src/core/dataframe.py
@@ -1,4 +1,5 @@
 import pandas as pd
+
 from src.util.check_functions import check_component_is_valid
 
 

--- a/src/core/interpretation_functions.py
+++ b/src/core/interpretation_functions.py
@@ -1,17 +1,10 @@
-from src.util.check_functions import (
-    check_arguments,
-    check_metric_value,
-    check_metric_values,
-    check_number_of_files,
-)
-from src.util.get_functions import (
-    get_files_data_frame,
-    get_test_root_dir,
-)
+import pandas as pd
 
 import src.core.measures_functions as ems_functions
-
-import pandas as pd
+from src.util.check_functions import (check_arguments, check_metric_value,
+                                      check_metric_values,
+                                      check_number_of_files)
+from src.util.get_functions import get_files_data_frame, get_test_root_dir
 
 
 def non_complex_files_density(data_frame):

--- a/src/core/interpretation_functions.py
+++ b/src/core/interpretation_functions.py
@@ -1,9 +1,12 @@
 import pandas as pd
 
 import src.core.measures_functions as ems_functions
-from src.util.check_functions import (check_arguments, check_metric_value,
-                                      check_metric_values,
-                                      check_number_of_files)
+from src.util.check_functions import (
+    check_arguments,
+    check_metric_value,
+    check_metric_values,
+    check_number_of_files,
+)
 from src.util.get_functions import get_files_data_frame, get_test_root_dir
 
 

--- a/src/core/measures_functions.py
+++ b/src/core/measures_functions.py
@@ -1,8 +1,9 @@
-import numpy as np
-import pandas as pd
 from typing import Dict
 
-from src.util.exceptions import InvalidMetricValue, ImplicitMetricValueError
+import numpy as np
+import pandas as pd
+
+from src.util.exceptions import ImplicitMetricValueError, InvalidMetricValue
 from src.util.get_functions import create_coordinate_pair
 
 

--- a/src/core/schemas.py
+++ b/src/core/schemas.py
@@ -1,4 +1,4 @@
-from marshmallow import Schema, fields
+from marshmallow import Schema, fields, validate
 
 
 class MeasureSchema(Schema):
@@ -40,6 +40,39 @@ class CalculateMeasureSchema(Schema):
     }
     """
     measures = fields.List(fields.Nested(MeasureSchema), required=True)
+
+
+class CalculatedSubEntitySchema(Schema):
+    key = fields.Str(required=True)
+    value = fields.Float(validate=validate.Range(min=0, max=1), required=True)
+    weight = fields.Float(validate=validate.Range(min=0, max=100), required=True)
+
+
+class SubCharacteristicSchema(Schema):
+    key = fields.Str(required=True)
+    measures = fields.List(fields.Nested(CalculatedSubEntitySchema), required=True)
+
+
+class CalculateSubCharacteristicSchema(Schema):
+    """
+    {
+        "subcharacteristics": [
+            {
+                "key": "testing_status",
+                "measures": [
+                    {
+                        "key": "passed_tests",
+                        "value": 1.0,
+                        "weight": 33,
+                    },
+                    ...
+                ]
+            },
+            ...
+        ]
+    }
+    """
+    subcharacteristics = fields.List(fields.Nested(SubCharacteristicSchema), required=True)
 
 
 class NonComplexFileDensitySchema(Schema):

--- a/src/core/weighting.py
+++ b/src/core/weighting.py
@@ -5,7 +5,9 @@ from src.util.exceptions import ValuesAndWeightsOfDifferentSizes
 
 def weighting_operation(values, weights):
     if len(values) != len(weights):
-        raise ValuesAndWeightsOfDifferentSizes("The length of weight and values are not equal")
+        raise ValuesAndWeightsOfDifferentSizes(
+            "The length of weight and values are not equal",
+        )
 
     values = np.array(values)
     weights = np.array(weights)

--- a/src/resources/analysis.py
+++ b/src/resources/analysis.py
@@ -5,11 +5,13 @@ from flask import jsonify, request
 from flask_restful import Resource
 from marshmallow.exceptions import ValidationError
 
-from src.core.analysis import (calculate_aggregated_value, calculate_measures,
-                               make_analysis)
+from src.core.analysis import (
+    calculate_aggregated_value,
+    calculate_measures,
+    make_analysis,
+)
 from src.core.dataframe import create_dataframe
-from src.core.schemas import (CalculateMeasureSchema,
-                              CalculateSubCharacteristicSchema)
+from src.core.schemas import CalculateMeasureSchema, CalculateSubCharacteristicSchema
 from src.util.constants import MEASURES_INTERPRETATION_MAPPING
 from src.util.exceptions import MeasureSoftGramCoreException
 

--- a/src/resources/analysis.py
+++ b/src/resources/analysis.py
@@ -1,16 +1,17 @@
 import random
+
 import requests
-
-from flask_restful import Resource
 from flask import jsonify, request
-
-from src.core.dataframe import create_dataframe
-from src.core.analysis import calculate_measures, make_analysis, calculate_aggregated_value
-from src.util.exceptions import MeasureSoftGramCoreException
-from src.util.constants import MEASURES_INTERPRETATION_MAPPING
-from src.core.schemas import CalculateMeasureSchema, CalculateSubCharacteristicSchema
-
+from flask_restful import Resource
 from marshmallow.exceptions import ValidationError
+
+from src.core.analysis import (calculate_aggregated_value, calculate_measures,
+                               make_analysis)
+from src.core.dataframe import create_dataframe
+from src.core.schemas import (CalculateMeasureSchema,
+                              CalculateSubCharacteristicSchema)
+from src.util.constants import MEASURES_INTERPRETATION_MAPPING
+from src.util.exceptions import MeasureSoftGramCoreException
 
 
 class Analysis(Resource):

--- a/src/resources/analysis.py
+++ b/src/resources/analysis.py
@@ -5,10 +5,10 @@ from flask_restful import Resource
 from flask import jsonify, request
 
 from src.core.dataframe import create_dataframe
-from src.core.analysis import calculate_measures, make_analysis
+from src.core.analysis import calculate_measures, make_analysis, calculate_aggregated_value
 from src.util.exceptions import MeasureSoftGramCoreException
 from src.util.constants import MEASURES_INTERPRETATION_MAPPING
-from src.core.schemas import CalculateMeasureSchema
+from src.core.schemas import CalculateMeasureSchema, CalculateSubCharacteristicSchema
 
 from marshmallow.exceptions import ValidationError
 
@@ -108,23 +108,34 @@ class CalculateMeasures(Resource):
 
 
 class CalculateSubcharacteristics(Resource):
-    """
-    Recurso mockado
-    TODO: Implementar
-    """
     def post(self):
-        return jsonify({
-            "subcharacteristics": [
-                {
-                    "key": "testing_status",
-                    "value": random.random()
-                },
-                {
-                    "key": "modifiability",
-                    "value": random.random()
-                }
-            ]
-        })
+        # Validates if the request data is valid
+        try:
+            data = CalculateSubCharacteristicSchema().load(request.get_json(force=True))
+        except ValidationError as error:
+            return {
+                "error": "Failed to validate request",
+                "schema_errors": error.messages,
+            }, requests.codes.unprocessable_entity
+
+        response_data = {"subcharacteristics": []}
+
+        for subcharacteristic in data["subcharacteristics"]:
+            subcharacteristic_key: str = subcharacteristic["key"]
+
+            values_list, weights_list = [], []
+            for measure in subcharacteristic["measures"]:
+                values_list.append(measure["value"])
+                weights_list.append(measure["weight"])
+
+            aggregated_value = calculate_aggregated_value(values_list, weights_list)
+
+            response_data["subcharacteristics"].append({
+                "key": subcharacteristic_key,
+                "value": aggregated_value,
+            })
+
+        return jsonify(response_data)
 
 
 class CalculateCharacteristics(Resource):

--- a/src/resources/available.py
+++ b/src/resources/available.py
@@ -1,5 +1,6 @@
-from flask_restful import Resource
 from flask import jsonify
+from flask_restful import Resource
+
 from src.util.constants import AVAILABLE_PRE_CONFIGS
 
 

--- a/src/util/check_functions.py
+++ b/src/util/check_functions.py
@@ -2,8 +2,10 @@ import math
 
 import pandas as pd
 
-from src.util.exceptions import (InvalidInterpretationFunctionArguments,
-                                 InvalidMetricValue)
+from src.util.exceptions import (
+    InvalidInterpretationFunctionArguments,
+    InvalidMetricValue,
+)
 
 
 def check_component_is_valid(component, language_extension):

--- a/src/util/check_functions.py
+++ b/src/util/check_functions.py
@@ -1,10 +1,9 @@
 import math
+
 import pandas as pd
 
-from src.util.exceptions import (
-    InvalidInterpretationFunctionArguments,
-    InvalidMetricValue
-)
+from src.util.exceptions import (InvalidInterpretationFunctionArguments,
+                                 InvalidMetricValue)
 
 
 def check_component_is_valid(component, language_extension):

--- a/src/util/constants.py
+++ b/src/util/constants.py
@@ -1,12 +1,15 @@
 import src.core.measures_functions as ems_functions
 from src.core import schemas
-from src.core.interpretation_functions import (absence_of_duplications,
-                                               ci_feedback_time,
-                                               commented_files_density,
-                                               fast_test_builds,
-                                               non_complex_files_density,
-                                               passed_tests, team_throughput,
-                                               test_coverage)
+from src.core.interpretation_functions import (
+    absence_of_duplications,
+    ci_feedback_time,
+    commented_files_density,
+    fast_test_builds,
+    non_complex_files_density,
+    passed_tests,
+    team_throughput,
+    test_coverage,
+)
 
 AVAILABLE_PRE_CONFIGS = {
     "characteristics": {

--- a/src/util/constants.py
+++ b/src/util/constants.py
@@ -1,17 +1,12 @@
-from src.core.interpretation_functions import (
-    ci_feedback_time,
-    non_complex_files_density,
-    test_coverage,
-    commented_files_density,
-    absence_of_duplications,
-    passed_tests,
-    fast_test_builds,
-    team_throughput
-)
 import src.core.measures_functions as ems_functions
-
-
 from src.core import schemas
+from src.core.interpretation_functions import (absence_of_duplications,
+                                               ci_feedback_time,
+                                               commented_files_density,
+                                               fast_test_builds,
+                                               non_complex_files_density,
+                                               passed_tests, team_throughput,
+                                               test_coverage)
 
 AVAILABLE_PRE_CONFIGS = {
     "characteristics": {

--- a/tests/integration/test_analysis.py
+++ b/tests/integration/test_analysis.py
@@ -3,6 +3,7 @@ from tests.utils.integration_data import (
     PRE_CONFIGURATION,
     COMPONENT,
     TEST_PARAMETERS,
+    CALCULATE_SUBCHARACTERISTICS_DATA,
 )
 from src.app import app
 
@@ -22,3 +23,15 @@ def test_analysis_sucess(status_code, level, expected_output):
 
         assert response.status_code == status_code
         assert response.json[level] == expected_output
+
+
+@pytest.mark.parametrize(
+    "data,status_code,expected_output",
+    CALCULATE_SUBCHARACTERISTICS_DATA
+)
+def test_calculate_subcharacteristics(data, status_code, expected_output):
+    with app.test_client() as client:
+        response = client.post("/calculate-subcharacteristics/", json=data)
+
+        assert response.status_code == status_code
+        assert response.json == expected_output

--- a/tests/unit/test_agregation.py
+++ b/tests/unit/test_agregation.py
@@ -1,4 +1,4 @@
-from src.core.agregation import agregation_operation
+from src.core.agregation import aggregation_operation
 from src.core.weighting import weighting_operation
 from tests.utils.aggregation_data import (
     WEIGHTS_1,
@@ -9,8 +9,8 @@ from tests.utils.aggregation_data import (
 import pytest
 
 
-def test_agregation_operation():
+def test_aggregation_operation():
     weighted_value_1 = weighting_operation(VALUES_1, WEIGHTS_1)
     weighted_value_2 = weighting_operation(VALUES_2, WEIGHTS_2)
-    assert pytest.approx(agregation_operation(weighted_value_1, WEIGHTS_1)) == 0.525711
-    assert pytest.approx(agregation_operation(weighted_value_2, WEIGHTS_2)) == 0.813749
+    assert pytest.approx(aggregation_operation(weighted_value_1, WEIGHTS_1)) == 0.525711
+    assert pytest.approx(aggregation_operation(weighted_value_2, WEIGHTS_2)) == 0.813749

--- a/tests/utils/integration_data.py
+++ b/tests/utils/integration_data.py
@@ -63,3 +63,115 @@ TEST_PARAMETERS = [
         {"sqc": 0.6596226503208683},
     ),
 ]
+
+
+CALCULATE_SUBCHARACTERISTICS_DATA = [
+    (
+        # Calculate one subcharacteristic
+        {
+            "subcharacteristics": [
+                {
+                    "key": "testing_status",
+                    "measures": [
+                        {
+                            "key": "passed_tests",
+                            "value": 1.0,
+                            "weight": 33
+                        },
+                        {
+                            "key": "test_builds",
+                            "value": 0.00178,
+                            "weight": 33
+                        },
+                        {
+                            "key": "test_coverage",
+                            "value": 0.25,
+                            "weight": 34
+                        }
+                    ]
+                }
+            ]
+        },
+        200,
+        {
+            "subcharacteristics": [
+                {
+                    "key": "testing_status",
+                    "value": 0.5901748671720202
+                }
+            ]
+        }
+    ),
+    (
+        # Calculate multiples subcharacteristics
+        {
+            "subcharacteristics": [
+                {
+                    "key": "modifiability",
+                    "measures": [
+                        {
+                            "key": "non_complex_file_density",
+                            "value": 0.675,
+                            "weight": 70
+                        },
+                        {
+                            "key": "commented_file_density",
+                            "value": 0.2275,
+                            "weight": 30
+                        }
+                    ]
+                },
+                {
+                    "key": "testing_status",
+                    "measures": [
+                        {
+                            "key": "test_builds",
+                            "value": 0.00178,
+                            "weight": 100
+                        }
+                    ]
+                }
+            ]
+        },
+        200,
+        {
+            "subcharacteristics": [
+                {
+                    "key": "modifiability",
+                    "value": 0.6268617959382247
+                },
+                {
+                    "key": "testing_status",
+                    "value": 0.00178
+                }
+            ]
+        }
+    ),
+    (
+        # Invalid request data
+        {
+            "subcharacteristics": [
+                {
+                    "key": "testing_status",
+                    "value": 0.5
+                }
+            ]
+        },
+        422,
+        {
+            "error": "Failed to validate request",
+            "schema_errors": {
+                "subcharacteristics": {
+                    "0": {
+                        "measures": [
+                            "Missing data for required field."
+                        ],
+                        "value": [
+                            "Unknown field."
+                        ]
+                    }
+                }
+            }
+        }
+    ),
+]


### PR DESCRIPTION
Closes #[204](https://github.com/fga-eps-mds/2022-1-MeasureSoftGram-Doc/issues/204)

## Descrição
Adiciona o endpoint `/calculate-subcharacteristics/` que calcula o valor agregado das subcaracterísticas solicitadas na requisição.

## Como testar:

1. Rode o `Core` localmente
2. Faça uma requisição para o endpoint `/calculate-subcharacteristics/` com o body necessário. Exemplo:
```bash
curl --location --request POST 'http://172.22.0.2:5000/calculate-subcharacteristics' \
--header 'Content-Type: application/json' \
--data-raw '{
    "subcharacteristics": [
        {
            "key": "modifiability",
            "measures": [
                {
                    "key": "non_complex_file_density",
                    "value": 0.675,
                    "weight": 50
                },
                {
                    "key": "commented_file_density",
                    "value": 0.2275,
                    "weight": 30
                },
                {
                    "key": "duplication_absense",
                    "value": 0.75,
                    "weight": 20
                }
            ]
        },
        {
            "key": "testing_status",
            "measures": [
                {
                    "key": "passed_tests",
                    "value": 1.0,
                    "weight": 33
                },
                {
                    "key": "test_builds",
                    "value": 0.00178,
                    "weight": 33
                },
                {
                    "key": "test_coverage",
                    "value": 0.25,
                    "weight": 34
                }
            ]
        }
    ]
}'
```
**Obs**: Pode ser necessário trocar o `host` do `Core` na requisição.
