### PR TITLE
Add endpoint to calculate `characteristics`

### DIFF
--- a/src/core/schemas.py
+++ b/src/core/schemas.py
@@ -75,6 +75,33 @@ class CalculateSubCharacteristicSchema(Schema):
     subcharacteristics = fields.List(fields.Nested(SubCharacteristicSchema), required=True)
 
 
+class CharacteristicSchema(Schema):
+    key = fields.Str(required=True)
+    subcharacteristics = fields.List(fields.Nested(CalculatedSubEntitySchema), required=True)
+
+
+class CalculateCharacteristicSchema(Schema):
+    """
+    {
+        "characteristics": [
+            {
+                "key": "reliability",
+                "subcharacteristics": [
+                    {
+                        "key": "testing_status",
+                        "value": 1.0,
+                        "weight": 50,
+                    },
+                    ...
+                ]
+            },
+            ...
+        ]
+    }
+    """
+    characteristics = fields.List(fields.Nested(CharacteristicSchema), required=True)
+
+
 class NonComplexFileDensitySchema(Schema):
     """
     "key": "non_complex_file_density",

--- a/tests/integration/test_analysis.py
+++ b/tests/integration/test_analysis.py
@@ -60,3 +60,4 @@ def test_calculate_with_invalid_data(entity, data):
         response = client.post(f"/calculate-{entity}/", json=data)
 
         assert response.status_code == 422
+        assert response.json["error"] == "Failed to validate request"

--- a/tests/integration/test_analysis.py
+++ b/tests/integration/test_analysis.py
@@ -3,7 +3,9 @@ from tests.utils.integration_data import (
     PRE_CONFIGURATION,
     COMPONENT,
     TEST_PARAMETERS,
-    CALCULATE_SUBCHARACTERISTICS_DATA,
+    CALCULATE_SUBCHARACTERISTICS_SUCCESS_DATA,
+    CALCULATE_CHARACTERISTICS_SUCCESS_DATA,
+    CALCULATE_ENTITY_INVALID_DATA,
 )
 from src.app import app
 
@@ -12,7 +14,7 @@ from src.app import app
     "status_code,level,expected_output",
     TEST_PARAMETERS
 )
-def test_analysis_sucess(status_code, level, expected_output):
+def test_analysis_success(status_code, level, expected_output):
     with app.test_client() as client:
         data = {
             "pre_config": PRE_CONFIGURATION,
@@ -26,12 +28,35 @@ def test_analysis_sucess(status_code, level, expected_output):
 
 
 @pytest.mark.parametrize(
-    "data,status_code,expected_output",
-    CALCULATE_SUBCHARACTERISTICS_DATA
+    "data,expected_output",
+    CALCULATE_SUBCHARACTERISTICS_SUCCESS_DATA
 )
-def test_calculate_subcharacteristics(data, status_code, expected_output):
+def test_calculate_subcharacteristics_success(data, expected_output):
     with app.test_client() as client:
         response = client.post("/calculate-subcharacteristics/", json=data)
 
-        assert response.status_code == status_code
+        assert response.status_code == 200
         assert response.json == expected_output
+
+
+@pytest.mark.parametrize(
+    "data,expected_output",
+    CALCULATE_CHARACTERISTICS_SUCCESS_DATA,
+)
+def test_calculate_characteristics_success(data, expected_output):
+    with app.test_client() as client:
+        response = client.post("/calculate-characteristics/", json=data)
+
+        assert response.status_code == 200
+        assert response.json == expected_output
+
+
+@pytest.mark.parametrize(
+    "entity,data",
+    CALCULATE_ENTITY_INVALID_DATA,
+)
+def test_calculate_with_invalid_data(entity, data):
+    with app.test_client() as client:
+        response = client.post(f"/calculate-{entity}/", json=data)
+
+        assert response.status_code == 422

--- a/tests/utils/integration_data.py
+++ b/tests/utils/integration_data.py
@@ -65,7 +65,7 @@ TEST_PARAMETERS = [
 ]
 
 
-CALCULATE_SUBCHARACTERISTICS_DATA = [
+CALCULATE_SUBCHARACTERISTICS_SUCCESS_DATA = [
     (
         # Calculate one subcharacteristic
         {
@@ -92,7 +92,6 @@ CALCULATE_SUBCHARACTERISTICS_DATA = [
                 }
             ]
         },
-        200,
         {
             "subcharacteristics": [
                 {
@@ -133,7 +132,6 @@ CALCULATE_SUBCHARACTERISTICS_DATA = [
                 }
             ]
         },
-        200,
         {
             "subcharacteristics": [
                 {
@@ -146,9 +144,81 @@ CALCULATE_SUBCHARACTERISTICS_DATA = [
                 }
             ]
         }
+    )
+]
+
+
+CALCULATE_CHARACTERISTICS_SUCCESS_DATA = [
+    (
+        # Calculate one characteristic
+        {
+            "characteristics": [
+                {
+                    "key": "reliability",
+                    "subcharacteristics": [
+                        {
+                            "key": "testing_status",
+                            "value": 0.90,
+                            "weight": 100
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "characteristics": [
+                {
+                    "key": "reliability",
+                    "value": 0.90
+                }
+            ]
+        }
     ),
     (
-        # Invalid request data
+        # Calculate multiples characteristics
+        {
+            "characteristics": [
+                {
+                    "key": "reliability",
+                    "subcharacteristics": [
+                        {
+                            "key": "testing_status",
+                            "value": 1.0,
+                            "weight": 100
+                        }
+                    ]
+                },
+                {
+                    "key": "maintainability",
+                    "subcharacteristics": [
+                        {
+                            "key": "modifiability",
+                            "value": 0.675,
+                            "weight": 100
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "characteristics": [
+                {
+                    "key": "reliability",
+                    "value": 1.0
+                },
+                {
+                    "key": "maintainability",
+                    "value": 0.675
+                }
+            ]
+        }
+    )
+]
+
+
+CALCULATE_ENTITY_INVALID_DATA = [
+    (
+        "subcharacteristics",
         {
             "subcharacteristics": [
                 {
@@ -156,22 +226,56 @@ CALCULATE_SUBCHARACTERISTICS_DATA = [
                     "value": 0.5
                 }
             ]
-        },
-        422,
+        }
+    ),
+    (
+        "subcharacteristics",
         {
-            "error": "Failed to validate request",
-            "schema_errors": {
-                "subcharacteristics": {
-                    "0": {
-                        "measures": [
-                            "Missing data for required field."
-                        ],
-                        "value": [
-                            "Unknown field."
-                        ]
-                    }
+            "subcharacteristics": [
+                {
+                    "key": "testing_status",
+                    "measures": [
+                        {
+                            "key": "passed_tests",
+                            "value": 0.00178
+                        }
+                    ]
                 }
-            }
+            ]
+        }
+    ),
+    (
+        "characteristics",
+        {
+            "characteristics": [
+                {
+                    "name": "reliability",
+                    "subcharacteristics": [
+                        {
+                            "key": "testing_status",
+                            "value": 2.5,
+                            "weight": 100
+                        }
+                    ]
+                }
+            ]
+        }
+    ),
+    (
+        "characteristics",
+        {
+            "characteristics": [
+                {
+                    "key": "reliability",
+                    "measures": [
+                        {
+                            "key": "test_builds",
+                            "value": 0.475,
+                            "weight": 100
+                        }
+                    ]
+                }
+            ]
         }
     ),
 ]


### PR DESCRIPTION
Closes #[248](https://github.com/fga-eps-mds/2022-1-MeasureSoftGram-Doc/issues/248)

## Descrição

- Adiciona o endpoint `/calculate-characteristics/` que calcula o valor agregado das subcaracterísticas solicitadas na requisição.
- Adiciona testes de integração para o endpoint `/calculate-characteristics/`

## Como testar:

1. Rode o `Core` localmente
2. Faça uma requisição para o endpoint `/calculate-characteristics/` com o body necessário. Exemplo:
```bash
curl --location --request POST 'http://localhost:5000/calculate-characteristics' \
--header 'Content-Type: application/json' \
--data-raw '{
    "characteristics": [
        {
            "key": "maintainability",
            "subcharacteristics": [
                {
                    "key": "modifiability",
                    "value": 0.675,
                    "weight": 100
                }
            ]
        },
        {
            "key": "reliability",
            "subcharacteristics": [
                {
                    "key": "testing_status",
                    "value": 0.78,
                    "weight": 100
                }
            ]
        }
    ]
}'
```
**Obs**: Pode ser necessário trocar o `host` do `Core` na requisição.
